### PR TITLE
로그인 완료 후, 리다이렉션 Url을 `/login/code`로 변경

### DIFF
--- a/back/src/main/kotlin/knu/dong/onedayonebaek/oauth/OAuth2SuccessHandler.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/oauth/OAuth2SuccessHandler.kt
@@ -3,9 +3,9 @@ package knu.dong.onedayonebaek.oauth
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
-import knu.dong.onedayonebaek.oauth.dto.Token
 import knu.dong.onedayonebaek.dto.UserDto
 import knu.dong.onedayonebaek.dto.toEntity
+import knu.dong.onedayonebaek.oauth.dto.Token
 import knu.dong.onedayonebaek.oauth.service.TokenService
 import knu.dong.onedayonebaek.repository.UserRepository
 import org.springframework.beans.factory.annotation.Value
@@ -50,7 +50,7 @@ class OAuth2SuccessHandler(
         response.addHeader("Refresh", token.refreshToken)
 
         val targetUrl = UriComponentsBuilder
-            .fromUriString("$clientDomain:$clientPort")
+            .fromUriString("$clientDomain:$clientPort/login/code")
             .queryParam("access", token.accessToken)
             .queryParam("refresh", token.refreshToken)
             .build().toUriString();


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- 로그인이 완료된 후, 리다이렉션 되는 경로를 `/`에서 `/login/code`로 변경

---

### ✨ 참고 사항
- `/login/code?access=<ac>&refresh=<rf>`의 형태로 감

---

### ⏰ 현재 버그

---

### ✏ Git Close
- related #25 
