### PR TITLE
현재 로그인된 유저가 특정 날짜에 해결한 문제 수를 조회하는 API 구현

### DIFF
--- a/back/src/main/kotlin/knu/dong/onedayonebaek/BackApplication.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/BackApplication.kt
@@ -1,10 +1,17 @@
 package knu.dong.onedayonebaek
 
+import jakarta.annotation.PostConstruct
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
+import java.util.*
 
 @SpringBootApplication
 class BackApplication
+
+@PostConstruct
+fun started() {
+    TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"))
+}
 
 fun main(args: Array<String>) {
     runApplication<BackApplication>(*args)

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/controller/CommitController.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/controller/CommitController.kt
@@ -1,6 +1,5 @@
 package knu.dong.onedayonebaek.controller
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -13,6 +12,7 @@ import knu.dong.onedayonebaek.service.CommitService
 import org.springframework.security.core.Authentication
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
 import java.time.YearMonth
 
 
@@ -47,5 +47,31 @@ class CommitController(private val commitService: CommitService) {
         val userDto = authentication.principal as UserDto
 
         return commitService.getCommits(userDto.loginId, yearMonth)
+    }
+
+    @Operation(
+        summary = "로그인된 유저의 특정 일자에 해결한 문제 개수 조회",
+        description = "로그인된 유저의 특정 일자에 해결한 문제 개수를 조회한다."
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "로그인된 유저의 특정 일자에 해당하는 해결한 문제 개수"),
+        ApiResponse(
+            responseCode = "400", description = "잘못된 Request Parameter",
+            content = [Content(schema = Schema(implementation = BadRequestResponse::class))],
+        )
+    )
+    @GetMapping("/count")
+    fun getCommitCountOfDay(
+        @Schema(
+            description = "커밋 개수를 조회하고 싶은 날짜",
+            required = true,
+            example = "2024-05-25"
+        )
+        date: LocalDate,
+        authentication: Authentication
+    ): Int {
+        val userDto = authentication.principal as UserDto
+
+        return commitService.getCommits(userDto.loginId, date).size
     }
 }

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/controller/CommitController.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/controller/CommitController.kt
@@ -22,11 +22,11 @@ import java.time.YearMonth
 class CommitController(private val commitService: CommitService) {
 
     @Operation(
-        summary = "로그인된 유저의 커밋 조회",
-        description = "로그인된 유저의 커밋들을 조회한다."
+        summary = "로그인된 유저가 해결한 문제 목록 조회",
+        description = "로그인된 유저가 특정 달에 해결한 문제 목록을 조회한다."
     )
     @ApiResponses(
-        ApiResponse(responseCode = "200", description = "로그인된 유저의 커밋 목록 조회"),
+        ApiResponse(responseCode = "200", description = "로그인된 유저의 문제 목록 조회"),
         ApiResponse(
             responseCode = "400", description = "잘못된 Request Parameter",
             content = [Content(schema = Schema(implementation = BadRequestResponse::class))],

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/repository/CommitRepository.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/repository/CommitRepository.kt
@@ -8,4 +8,5 @@ import java.time.LocalDate
 
 interface CommitRepository: JpaRepository<Commit, Long> {
     fun findAllByCommitDateBetweenAndUser(start: LocalDate, end: LocalDate, user: User): List<Commit>
+    fun findAllByCommitDateAndUser(date: LocalDate, user: User): List<Commit>
 }

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/service/CommitService.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/service/CommitService.kt
@@ -6,6 +6,7 @@ import knu.dong.onedayonebaek.dto.toCommitInfo
 import knu.dong.onedayonebaek.repository.CommitRepository
 import knu.dong.onedayonebaek.repository.UserRepository
 import org.springframework.stereotype.Service
+import java.time.LocalDate
 import java.time.YearMonth
 import java.util.stream.Collectors
 
@@ -28,5 +29,15 @@ class CommitService(
         .stream()
         .map { it.toCommitInfo() }
         .collect(Collectors.toList())
+    }
+
+    fun getCommits(loginId: String, date: LocalDate): List<CommitInfo> {
+        val user = userRepository.getByLoginId(loginId)
+
+        return commitRepository
+            .findAllByCommitDateAndUser(date, user)
+            .stream()
+            .map { it.toCommitInfo() }
+            .collect(Collectors.toList())
     }
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
- server timezone 설정
    - 배포 서버의 시스템 타임존과 mysql도 같이 변경해둠
- `GET /commits/count` 구현
    - 현재 로그인된 유저가 특정 날짜에 해결한 문제 수를 조회

---

### ✨ 참고 사항

---

### ⏰ 현재 버그

---

### ✏ Git Close
- related #35 