### PR TITLE
깃헙 로그인 API 연결

### DIFF
--- a/front/.eslintrc.cjs
+++ b/front/.eslintrc.cjs
@@ -14,7 +14,12 @@ module.exports = {
   settings: {
     react: { version: '18.2' },
   },
-  ignorePatterns: ['dist', '.eslintrc.cjs', 'vite.config.ts'],
+  ignorePatterns: [
+    'dist',
+    '.eslintrc.cjs',
+    'vite.config.ts',
+    'public/mockServiceWorker.js',
+  ],
   parser: '@typescript-eslint/parser',
   parserOptions: {
     project: true,

--- a/front/.gitignore
+++ b/front/.gitignore
@@ -22,3 +22,5 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env

--- a/front/package.json
+++ b/front/package.json
@@ -20,6 +20,7 @@
     "react": "^18.2.0",
     "react-calendar": "^5.0.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "react-icons": "^5.2.1",
     "react-router-dom": "^6.23.1",
     "styled-components": "^6.1.11",

--- a/front/pnpm-lock.yaml
+++ b/front/pnpm-lock.yaml
@@ -29,6 +29,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.3.1(react@18.3.1)
+  react-hot-toast:
+    specifier: ^2.4.1
+    version: 2.4.1(csstype@3.1.3)(react-dom@18.3.1)(react@18.3.1)
   react-icons:
     specifier: ^5.2.1
     version: 5.2.1(react@18.3.1)
@@ -3039,6 +3042,14 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /goober@2.1.14(csstype@3.1.3):
+    resolution: {integrity: sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.3
+    dev: false
+
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -4020,6 +4031,20 @@ packages:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  /react-hot-toast@2.4.1(csstype@3.1.3)(react-dom@18.3.1)(react@18.3.1):
+    resolution: {integrity: sha512-j8z+cQbWIM5LY37pR6uZR6D4LfseplqnuAO4co4u8917hBUvXlEqyP1ZzqVLcqoyUesZZv/ImreoCeHVDpE5pQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      goober: 2.1.14(csstype@3.1.3)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - csstype
+    dev: false
 
   /react-icons@5.2.1(react@18.3.1):
     resolution: {integrity: sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==}

--- a/front/src/Router.tsx
+++ b/front/src/Router.tsx
@@ -6,6 +6,7 @@ import GroupMemberPage from '@pages/group/GroupMemberPage';
 import GroupPage from '@pages/group/GroupPage';
 import GroupSelectionPage from '@pages/group/GroupSelectionPage';
 import LoginPage from '@pages/login/LoginPage';
+import LoginRedirectPage from '@pages/login/LoginRedirectPage';
 import RootPage from '@pages/root/RootPage';
 import SearchPage from '@pages/search/SearchPage';
 

--- a/front/src/Router.tsx
+++ b/front/src/Router.tsx
@@ -29,4 +29,8 @@ export const Router = createBrowserRouter([
       },
     ],
   },
+  {
+    path: '/login/code',
+    element: <LoginRedirectPage />,
+  },
 ]);

--- a/front/src/components/alarm/ToastProvider.tsx
+++ b/front/src/components/alarm/ToastProvider.tsx
@@ -1,0 +1,55 @@
+import { ReactNode } from 'react';
+import { Toaster, ToastBar } from 'react-hot-toast';
+import { BiCheckCircle, BiErrorCircle } from 'react-icons/bi';
+
+import styled from '@emotion/styled';
+
+interface IToastProviderProps {
+  children: ReactNode;
+}
+
+const StyledToastBar = styled(ToastBar)`
+  background-color: #ffffff;
+  color: #333333;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  margin-top: 8px;
+`;
+
+const ToastProvider = ({ children }: IToastProviderProps) => {
+  return (
+    <>
+      <Toaster
+        position='top-center'
+        reverseOrder={false}
+        gutter={8}
+        toastOptions={{
+          success: {
+            style: {
+              background: 'var(--color-green)',
+              color: 'white',
+              boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+              fontSize: 'var(--size-sm)',
+            },
+            icon: <BiCheckCircle size={20} color='var(--color-white)' />,
+          },
+          error: {
+            style: {
+              background: 'var(--color-red)',
+              color: 'var(--color-white)',
+              boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+              border: '1px solid var(--color-red)',
+              fontSize: 'var(--size-sm)',
+            },
+            icon: <BiErrorCircle size={20} color='var(--color-white)' />,
+          },
+        }}
+      >
+        {(t) => <StyledToastBar toast={t} />}
+      </Toaster>
+      {children}
+    </>
+  );
+};
+
+export default ToastProvider;

--- a/front/src/components/header/MainNavigation.tsx
+++ b/front/src/components/header/MainNavigation.tsx
@@ -1,8 +1,12 @@
+import { useEffect } from 'react';
+import toast from 'react-hot-toast';
 import { BiBell, BiLogIn, BiLogOut } from 'react-icons/bi';
 
 import LinkText from '@components/typography/LinkText';
 
 import HaedalText from '@assets/HaedalText.png';
+
+import { useTokenStore } from '@stores/useTokenStore';
 
 import styled from '@emotion/styled';
 
@@ -47,7 +51,26 @@ const LogoImg = styled.img`
 `;
 
 const MainNavigation = () => {
-  const isAccessToken = localStorage.getItem('accessToken');
+  const { isAccessToken, setIsAccessToken } = useTokenStore();
+
+  useEffect(() => {
+    const handleStorageChange = () => {
+      setIsAccessToken(localStorage.getItem('aId') !== null);
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+
+    return () => {
+      window.removeEventListener('storage', handleStorageChange);
+    };
+  }, [setIsAccessToken]);
+
+  const onClickLogout = () => {
+    localStorage.removeItem('aId');
+    localStorage.removeItem('rId');
+    setIsAccessToken(false);
+    toast.success('로그아웃 되었습니다.');
+  };
 
   return (
     <MainNavigateDiv>
@@ -93,7 +116,7 @@ const MainNavigation = () => {
           </MainNavigateItem>
           {isAccessToken ? (
             <MainNavigateItem>
-              <BiLogOut size={21} aria-label='logout' />
+              <BiLogOut size={21} aria-label='logout' onClick={onClickLogout} />
             </MainNavigateItem>
           ) : (
             <MainNavigateItem>

--- a/front/src/components/header/MainNavigation.tsx
+++ b/front/src/components/header/MainNavigation.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 import { BiBell, BiLogIn, BiLogOut } from 'react-icons/bi';
 
@@ -52,18 +51,6 @@ const LogoImg = styled.img`
 
 const MainNavigation = () => {
   const { isAccessToken, setIsAccessToken } = useTokenStore();
-
-  useEffect(() => {
-    const handleStorageChange = () => {
-      setIsAccessToken(localStorage.getItem('aId') !== null);
-    };
-
-    window.addEventListener('storage', handleStorageChange);
-
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, [setIsAccessToken]);
 
   const onClickLogout = () => {
     localStorage.removeItem('aId');

--- a/front/src/constants/URI.ts
+++ b/front/src/constants/URI.ts
@@ -1,0 +1,1 @@
+export const BASE_URI = import.meta.env.VITE_BASE_URL;

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -1,5 +1,7 @@
 import ReactDOM from 'react-dom/client';
 
+import ToastProvider from '@components/alarm/ToastProvider';
+
 import App from '@/App';
 import { worker } from '@mocks/Browser';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -19,7 +21,9 @@ const enableMocking = async () => {
 enableMocking().then(() => {
   ReactDOM.createRoot(document.getElementById('root')!).render(
     <QueryClientProvider client={queryClient}>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
       <ReactQueryDevtools initialIsOpen={false} />
     </QueryClientProvider>
   );

--- a/front/src/main.tsx
+++ b/front/src/main.tsx
@@ -14,7 +14,7 @@ const enableMocking = async () => {
     return;
   }
 
-  console.log('start!');
+  // console.log('start!');
   return worker.start();
 };
 

--- a/front/src/pages/login/LoginRedirectPage.tsx
+++ b/front/src/pages/login/LoginRedirectPage.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+const LoginRedirectPage = () => {
+  const [searchParams] = useSearchParams();
+
+  useEffect(() => {
+    const accessToken = searchParams.get('access');
+    const refreshToken = searchParams.get('refresh');
+
+    if (accessToken) {
+      localStorage.setItem('aId', accessToken);
+    }
+    if (refreshToken) {
+      localStorage.setItem('rId', refreshToken);
+    }
+  }, [searchParams]);
+
+  return <></>;
+};
+
+export default LoginRedirectPage;

--- a/front/src/pages/login/LoginRedirectPage.tsx
+++ b/front/src/pages/login/LoginRedirectPage.tsx
@@ -18,8 +18,8 @@ const LoginRedirectPage = () => {
       localStorage.setItem('rId', refreshToken);
     }
 
-    navigate('/');
     toast.success('환영합니다! 김규회님!');
+    navigate('/');
   }, [searchParams, navigate]);
 
   return <></>;

--- a/front/src/pages/login/LoginRedirectPage.tsx
+++ b/front/src/pages/login/LoginRedirectPage.tsx
@@ -3,9 +3,12 @@ import toast from 'react-hot-toast';
 import { useSearchParams } from 'react-router-dom';
 import { useNavigate } from 'react-router-dom';
 
+import { useTokenStore } from '@stores/useTokenStore';
+
 const LoginRedirectPage = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const { setIsAccessToken } = useTokenStore();
 
   useEffect(() => {
     const accessToken = searchParams.get('access');
@@ -18,9 +21,10 @@ const LoginRedirectPage = () => {
       localStorage.setItem('rId', refreshToken);
     }
 
-    toast.success('환영합니다! 김규회님!');
+    setIsAccessToken(localStorage.getItem('aId') !== null);
     navigate('/');
-  }, [searchParams, navigate]);
+    toast.success('환영합니다! 김규회님!');
+  }, [searchParams, navigate, setIsAccessToken]);
 
   return <></>;
 };

--- a/front/src/pages/login/LoginRedirectPage.tsx
+++ b/front/src/pages/login/LoginRedirectPage.tsx
@@ -1,8 +1,11 @@
 import { useEffect } from 'react';
+import toast from 'react-hot-toast';
 import { useSearchParams } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 
 const LoginRedirectPage = () => {
   const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const accessToken = searchParams.get('access');
@@ -14,7 +17,10 @@ const LoginRedirectPage = () => {
     if (refreshToken) {
       localStorage.setItem('rId', refreshToken);
     }
-  }, [searchParams]);
+
+    navigate('/');
+    toast.success('환영합니다! 김규회님!');
+  }, [searchParams, navigate]);
 
   return <></>;
 };

--- a/front/src/pages/login/components/GithubButton.tsx
+++ b/front/src/pages/login/components/GithubButton.tsx
@@ -2,6 +2,8 @@ import { BiLogoGithub } from 'react-icons/bi';
 
 import { DefaultButton } from '@components/button/DefaultButton';
 
+import { BASE_URI } from '@constants/URI';
+
 import styled from '@emotion/styled';
 
 const GithubStyledButton = styled(DefaultButton)`
@@ -28,7 +30,7 @@ const GithubStyledButton = styled(DefaultButton)`
 
 const GithubButton = () => {
   const onClickLogin = () => {
-    window.location.href = 'http://localhost:8080/oauth2/authorization/github';
+    window.location.href = `${BASE_URI}/oauth2/authorization/github`;
   };
 
   return (

--- a/front/src/stores/useTokenStore.ts
+++ b/front/src/stores/useTokenStore.ts
@@ -1,0 +1,14 @@
+import { create } from 'zustand';
+
+interface ITokenStore {
+  isAccessToken: boolean;
+}
+
+interface ITokenActionStore extends ITokenStore {
+  setIsAccessToken: (value: boolean) => void;
+}
+
+export const useTokenStore = create<ITokenActionStore>((set) => ({
+  isAccessToken: localStorage.getItem('aId') !== null,
+  setIsAccessToken: (value) => set(() => ({ isAccessToken: value })),
+}));

--- a/front/src/styles/GlobalStyles.ts
+++ b/front/src/styles/GlobalStyles.ts
@@ -15,6 +15,7 @@ const colorBlack = '#000000';
 const colorGray = '#d9d9d9';
 const colorBlue = '#4285F4';
 const colorRed = '#ff6f61';
+const colorGreen = '#4CAF50';
 const colorLightYellow = '#fff5e6';
 const colorBorderYellow = '#ffebcd';
 const colorSpacePrimary = '#04094f';
@@ -38,6 +39,7 @@ export const GlobalStyle = css`
     --color-gray: ${colorGray};
     --color-blue: ${colorBlue};
     --color-red: ${colorRed};
+    --color-green: ${colorGreen};
     --color-lyellow: ${colorLightYellow};
     --color-byellow: ${colorBorderYellow};
     --color-space-primary: ${colorSpacePrimary};

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -36,6 +36,6 @@
       "@mocks/*": ["src/mocks/*"]
     }
   },
-  "include": ["src", "vite.config.ts"],
+  "include": ["src", "vite.config.ts", "public/mockServiceWorker.js"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용

---

- [ ] 깃헙 로그인 연결
- [ ] Toast 라이브러리 설치 및 환경 설정
- [ ] 깃헙 로그인시 navigate 되도록 구현

### ✨ 참고 사항

---
- 토큰을 저장할 떄 현재 AccessToken, RefreshToken을 LocalStorage에 저장되더있도록 구현되어있습니다.
   - 추후 리팩토링하여 토큰 저장 장소를 바꿀 계획입니다.
- ToastProvider 세팅
```
enableMocking().then(() => {
  ReactDOM.createRoot(document.getElementById('root')!).render(
    <QueryClientProvider client={queryClient}>
      <ToastProvider>
        <App />
      </ToastProvider>
      <ReactQueryDevtools initialIsOpen={false} />
    </QueryClientProvider>
  );
});

```    

### ⏰ 현재 버그

---
x

### ✏ Git Close

close #27

