### PR TITLE
그룹 조회 API의 응답에 사용자가 속한 그룹인지를 나타내는 필드 추가

### DIFF
--- a/back/src/main/kotlin/knu/dong/onedayonebaek/group/controller/GroupController.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/group/controller/GroupController.kt
@@ -42,7 +42,7 @@ class GroupController(
         description = "모든 그룹을 조회한다."
     )
     @GetMapping
-    fun getGroups() = groupService.getGroups()
+    fun getGroups(authentication: Authentication) = groupService.getGroups(authentication.principal as User)
 
     @Operation(
         summary = "스터디 그룹 상세 조회",

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/group/dto/GroupDetailDto.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/group/dto/GroupDetailDto.kt
@@ -25,6 +25,9 @@ data class GroupDetailDto(
     @Schema(description = "문제를 풀지 않은 날 매겨지는 벌금", nullable = false, example = "1000")
     val fine: Int,
 
+    @Schema(description = "해당 그룹에 속해있는지 여부", nullable = false, example = "false")
+    val isMember: Boolean,
+
     @Schema(description = "그룹에 속한 유저", nullable = false)
     val users: List<UserDto>,
 
@@ -32,15 +35,16 @@ data class GroupDetailDto(
     val owner: UserDto
 )
 
-fun Group.toGroupDetailDto() =
+fun Group.toGroupDetailDto(isMember: Boolean) =
     GroupDetailDto(
-        id!!,
-        name,
-        isPrivate,
-        inviteCode,
-        goalSolveCount,
-        fine,
-        users.map { it.user.toUserDto() },
-        owner.toUserDto()
+        id = id!!,
+        name = name,
+        isPrivate = isPrivate,
+        inviteCode = inviteCode,
+        goalSolveCount = goalSolveCount,
+        fine = fine,
+        isMember = isMember,
+        users = users.map { it.user.toUserDto() },
+        owner = owner.toUserDto()
     )
 

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/group/dto/GroupOfListDto.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/group/dto/GroupOfListDto.kt
@@ -11,7 +11,10 @@ data class GroupOfListDto(
     val name: String,
 
     @Schema(description = "비밀 그룹 여부", nullable = false, example = "false")
-    val isPrivate: Boolean
+    val isPrivate: Boolean,
+
+    @Schema(description = "해당 그룹에 속해있는지 여부", nullable = false, example = "false")
+    val isMember: Boolean
 )
 
-fun Group.toGroupOfListDto() = GroupOfListDto(id!!, name, isPrivate)
+fun Group.toGroupOfListDto(isMember: Boolean) = GroupOfListDto(id!!, name, isPrivate, isMember)

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/group/service/GroupService.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/group/service/GroupService.kt
@@ -43,9 +43,10 @@ class GroupService (
 
     fun getGroupDetail(user: User, groupId: Long): GroupDetailDto {
         val group = groupRepository.findById(groupId).orElseThrow{ NotFoundException(message = "해당 그룹이 없습니다.") }
+        val isMember = containGroupRepository.existsByGroupAndUser(group, user)
 
-        if (!group.isPrivate || containGroupRepository.existsByGroupAndUser(group, user)) {
-            return group.toGroupDetailDto()
+        if (!group.isPrivate || isMember) {
+            return group.toGroupDetailDto(isMember = isMember)
         }
 
         throw ForbiddenException(message = "해당 비밀 그룹에 속해있지 않습니다.")
@@ -71,7 +72,7 @@ class GroupService (
 
         createdGroup.users.add(createdCG)
 
-        return group.toGroupDetailDto()
+        return group.toGroupDetailDto(isMember = true)
     }
 
     @Transactional
@@ -95,7 +96,7 @@ class GroupService (
 
         val updatedGroup = groupRepository.save(existingGroup)
 
-        return updatedGroup.toGroupDetailDto()
+        return updatedGroup.toGroupDetailDto(isMember = true)
     }
 
     @Transactional
@@ -109,7 +110,7 @@ class GroupService (
         if (!group.isPrivate) {
             containGroupRepository.save(ContainGroup(user, group))
 
-            return group.toGroupDetailDto()
+            return group.toGroupDetailDto(isMember = true)
         }
 
         if (password == null) {
@@ -121,7 +122,7 @@ class GroupService (
         if (isCorrectPW) {
             containGroupRepository.save(ContainGroup(user, group))
 
-            return group.toGroupDetailDto()
+            return group.toGroupDetailDto(isMember = true)
         }
 
         throw ConflictException("incorrect_password", "비밀번호가 다릅니다.")
@@ -139,7 +140,7 @@ class GroupService (
 
         containGroupRepository.save(ContainGroup(user, group))
 
-        return group.toGroupDetailDto()
+        return group.toGroupDetailDto(isMember = true)
     }
 
     @Transactional

--- a/back/src/main/kotlin/knu/dong/onedayonebaek/group/service/GroupService.kt
+++ b/back/src/main/kotlin/knu/dong/onedayonebaek/group/service/GroupService.kt
@@ -31,11 +31,15 @@ class GroupService (
     private val problemRepository: ProblemRepository,
     private val passwordEncoder: PasswordEncoder
 ){
-    fun getGroups(): List<GroupOfListDto> = groupRepository.findAll().map { it.toGroupOfListDto() }
+    fun getGroups(user: User): List<GroupOfListDto> {
+        val userGroupIds = containGroupRepository.findAllByUser(user).map { it.group.id }
+
+        return groupRepository.findAll().map { it.toGroupOfListDto(isMember = (it.id in userGroupIds)) }
+    }
 
 
     fun getGroupsOfUser(user: User): List<GroupOfListDto> =
-        containGroupRepository.findAllByUser(user).map { it.group.toGroupOfListDto() }
+        containGroupRepository.findAllByUser(user).map { it.group.toGroupOfListDto(isMember = true) }
 
     fun getGroupDetail(user: User, groupId: Long): GroupDetailDto {
         val group = groupRepository.findById(groupId).orElseThrow{ NotFoundException(message = "해당 그룹이 없습니다.") }


### PR DESCRIPTION
## **PR**

### ✨ 작업 내용
-그룹 목록 조회 API의 응답에 isMember 필드 추가
- GroupDetailDto를 사용하는 API(상세 조회, 생성, 조인 등)의 응답에 isMember 필드 추가

---

### ✏ Git Close
- related #70 
